### PR TITLE
add Chinese Simplified(zh_CN) translation

### DIFF
--- a/harbour-batagur/translations/harbour-batagur-zh_CN.ts
+++ b/harbour-batagur/translations/harbour-batagur-zh_CN.ts
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>About</name>
+    <message>
+        <source>About</source>
+        <translation>关于</translation>
+    </message>
+    <message>
+        <source>Author</source>
+        <translation type="vanished">作者</translation>
+    </message>
+    <message>
+        <source>AuthorText</source>
+        <translation type="vanished">toerb (https://github.com/toerb/batagur/)</translation>
+    </message>
+    <message>
+        <source>Passwords</source>
+        <translation>密码</translation>
+    </message>
+    <message>
+        <source>PasswordsText</source>
+        <translation>密码文本</translation>
+    </message>
+    <message>
+        <source>Licences</source>
+        <translation>许可协议</translation>
+    </message>
+    <message>
+        <source>LicencesText</source>
+        <translation>许可协议文本</translation>
+    </message>
+</context>
+<context>
+    <name>Input</name>
+    <message>
+        <source>About</source>
+        <translation>关于</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>设置</translation>
+    </message>
+</context>
+<context>
+    <name>Password</name>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation>复制到剪贴板</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>密码</translation>
+    </message>
+    <message>
+        <source>Clear Clipboard</source>
+        <translation>清空剪贴板</translation>
+    </message>
+</context>
+<context>
+    <name>Settings</name>
+    <message>
+        <source>Salt</source>
+        <translation>盐</translation>
+    </message>
+    <message>
+        <source>Iterations</source>
+        <translation>迭代次数</translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation>长度</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Thx for your work. Add the Chinese Simplified(zh_CN, used in China Mainland) translation.

1. It looks like the translation file is incompleted. The text in `About` page is missing. Could you please fix that?
2. Could you also update the Chinese translation of app description in Jolla Store? Thx

The Chinese translation of app description in Jolla Store:

* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

一个可以哈希且不会本地存储密码的密码管理器。
<br />

Batagur通过哈希主密码和服务token来生成密码。

主密码和token是可选的。你必须在每次生成密码前输入的参数：
* 盐 - 在哈希时使用的文本，介于主密码和token之间
* 迭代次数指字符串将被SHA512哈希的次数
* 密码长度 - 1到79个字符串
<br />

JavaScript的实现请访问项目主页。